### PR TITLE
Cleanup Tasks; FSE-188; Bump version to 0.3.2.dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Chef Init Changelog
 
+## Unreleased
+* [FSE-188] Method for stripping secure credentials resulted in intermediate
+image with those credentials still present. Stripping out those intermediate
+layers is now the responsibility of `chef-init --bootstrap`. Reported by Andrew
+Hsu.
+
 ## v0.3.1 (2014-08-13)
 * Fixed bug when load_current_resource does not pass in run_context to service
 resource.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Chef Init Changelog
 
-## Unreleased
+## v0.3.2 (Unreleased)
 * [FSE-188] Method for stripping secure credentials resulted in intermediate
 image with those credentials still present. Stripping out those intermediate
 layers is now the responsibility of `chef-init --bootstrap`. Reported by Andrew

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 FROM chef/ubuntu-12.04:latest
-COPY pkg/chef-init-0.3.0.gem chef-init.gem
+COPY pkg/chef-init-1.0.0.rc.0.gem chef-init.gem
 RUN /opt/chef/embedded/bin/gem install chef-init.gem --bindir '/opt/chef/bin' --no-ri --no-rdoc

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # chef-init
-[![Gem Version](https://badge.fury.io/rb/chef-init.png)](http://badge.fury.io/rb/chef-init) [![Build Status](https://travis-ci.org/opscode/chef-init.svg?branch=master)](https://travis-ci.org/opscode/chef-init)
+[![Build Status](https://travis-ci.org/opscode/chef-init.svg?branch=master)](https://travis-ci.org/opscode/chef-init)
 
-chef-init is a RubyGem that is distributed with [chef-container] and intended to be used as PID1 inside Linux Containers. 
+chef-init is a RubyGem that is distributed with [chef-container] and intended to be used as PID1 inside Linux Containers.
 
-Its primary purpose is to provide an interface with which to safely launch a chef-client run and a process supervisor to manage the services that your Chef recipes create. 
+Its primary purpose is to provide an interface with which to safely launch a chef-client run and a process supervisor to manage the services that your Chef recipes create.
 
 Its secondary purpose is to provide useful Chef Resources and Recipe DSLs that you can use to interface more cleanly with the process supervisor.
 
 ## Installation
-This RubyGem is already bundled with [chef-container] and should not be install separately at this time.
+This RubyGem is already bundled with [chef-container](http://github.com/opscode/chef-container) and should not be install separately.
 
 ## Usage
 Check out the documentation [here](http://docs.opscode.com/containers.html)
@@ -36,4 +36,3 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-

--- a/lib/chef-init/cli.rb
+++ b/lib/chef-init/cli.rb
@@ -58,6 +58,12 @@ module ChefInit
       :boolean      => true,
       :default      => false
 
+    option :remove_secure,
+      :long         => "--[no-]remove-secure",
+      :description  => "Remove secure credentials from image.",
+      :boolean      => true,
+      :default      => true
+
     option :verify,
       :long         => "--verify",
       :description  => "Verify installation",
@@ -201,6 +207,8 @@ module ChefInit
       delete_client_key
       ChefInit::Log.debug("Removing node name file...")
       delete_node_name_file
+      ChefInit::Log.info("Emptying secure folder...")
+      empty_secure_directory if config[:remove_secure]
 
       shutdown_supervisor
 
@@ -307,6 +315,10 @@ module ChefInit
 
     def supervisor_launch_command
       "#{omnibus_embedded_bin_dir}/runsvdir -P #{omnibus_root}/service 'log: #{ '.' * 395}'"
+    end
+
+    def empty_secure_directory
+      FileUtils.rm_rf("/etc/chef/secure/.", secure: true)
     end
 
     def delete_client_key

--- a/lib/chef-init/cli.rb
+++ b/lib/chef-init/cli.rb
@@ -220,13 +220,7 @@ module ChefInit
     #
     def launch_supervisor
       fork do
-        exec(
-          {"PATH" => path},
-          "#{omnibus_embedded_bin_dir}/runsvdir",
-          "-P",
-          "#{omnibus_root}/service",
-          "'log: #{ '.' * 395}'"
-        )
+        exec({"PATH" => path}, supervisor_launch_command)
       end
     end
 

--- a/lib/chef-init/version.rb
+++ b/lib/chef-init/version.rb
@@ -16,5 +16,5 @@
 #
 
 module ChefInit
-  VERSION = "0.3.1"
+  VERSION = "0.3.2.dev"
 end

--- a/spec/unit/chef-init/cli_spec.rb
+++ b/spec/unit/chef-init/cli_spec.rb
@@ -295,6 +295,7 @@ describe ChefInit::CLI do
       cli.stub(:delete_client_key)
       cli.stub(:delete_node_name_file)
       cli.stub(:shutdown_supervisor)
+      cli.stub(:empty_secure_directory)
       cli.stub(:kill)
     end
 
@@ -339,6 +340,22 @@ describe ChefInit::CLI do
       expect(cli).to receive(:exit).with(true)
       cli.launch_bootstrap
     end
+
+    it "deletes the secure directory" do
+      expect(cli).to receive(:empty_secure_directory)
+      expect(cli).to receive(:exit).with(true)
+      cli.launch_bootstrap
+    end
+
+    context "when --no-delete-secure is specified" do
+      before { cli.config[:remove_secure] = false }
+      it "does not delete the secure directory" do
+        expect(cli).not_to receive(:empty_secure_directory)
+        expect(cli).to receive(:exit).with(true)
+        cli.launch_bootstrap
+      end
+    end
+
   end
 
   describe "#launch_supervisor" do

--- a/spec/unit/chef-init/cli_spec.rb
+++ b/spec/unit/chef-init/cli_spec.rb
@@ -34,26 +34,26 @@ describe ChefInit::CLI do
   end
 
   before do
-    ChefInit::Log.stub(:info)
+    allow(ChefInit::Log).to receive(:info)
 
     # by default, we are running in local-mode
-    File.stub(:exist?).with("/etc/chef/zero.rb").and_return(true)
-    File.stub(:exist?).with("/etc/chef/.node_name").and_return(false)
-    File.stub(:exist?).with("/etc/chef/secure/validation.pem").and_return(true)
-    File.stub(:exist?).with("/etc/chef/secure/client.pem").and_return(false)
+    allow(File).to receive(:exist?).with("/etc/chef/zero.rb").and_return(true)
+    allow(File).to receive(:exist?).with("/etc/chef/.node_name").and_return(false)
+    allow(File).to receive(:exist?).with("/etc/chef/secure/validation.pem").and_return(true)
+    allow(File).to receive(:exist?).with("/etc/chef/secure/client.pem").and_return(false)
   end
 
   subject(:cli) do
     ChefInit::CLI.new(argv, max_retries).tap do |c|
-      c.stub(:stdout).and_return(stdout_io)
-      c.stub(:stderr).and_return(stderr_io)
+      allow(c).to receive(:stdout).and_return(stdout_io)
+      allow(c).to receive(:stderr).and_return(stderr_io)
     end
   end
 
   describe "#run" do
     before do
-      cli.stub(:launch_onboot)
-      cli.stub(:launch_bootstrap)
+      allow(cli).to receive(:launch_onboot)
+      allow(cli).to receive(:launch_bootstrap)
     end
 
     describe "when the application starts" do
@@ -99,7 +99,7 @@ describe ChefInit::CLI do
       let(:verify) { double("ChefInit::Verify", run: nil) }
 
       it "runs the verification process" do
-        ChefInit::Verify.stub(:new).and_return(verify)
+        allow(ChefInit::Verify).to receive(:new).and_return(verify)
         expect(verify).to receive(:run)
         cli.run
       end
@@ -141,8 +141,8 @@ describe ChefInit::CLI do
   describe "#set_default_options" do
     context "when zero.rb exists" do
       before do
-        File.stub(:exist?).with("/etc/chef/zero.rb").and_return(true)
-        File.stub(:exist?).with("/etc/chef/client.rb").and_return(false)
+        allow(File).to receive(:exist?).with("/etc/chef/zero.rb").and_return(true)
+        allow(File).to receive(:exist?).with("/etc/chef/client.rb").and_return(false)
       end
 
       it "sets local-mode defaults" do
@@ -153,8 +153,8 @@ describe ChefInit::CLI do
 
     context "when client.rb exists" do
       before do
-        File.stub(:exist?).with("/etc/chef/zero.rb").and_return(false)
-        File.stub(:exist?).with("/etc/chef/client.rb").and_return(true)
+        allow(File).to receive(:exist?).with("/etc/chef/zero.rb").and_return(false)
+        allow(File).to receive(:exist?).with("/etc/chef/client.rb").and_return(true)
       end
 
       it "sets client-mode defaults" do
@@ -164,10 +164,10 @@ describe ChefInit::CLI do
 
       context "with missing validator and client keys" do
         before do
-          File.stub(:exist?).with("/etc/chef/client.rb").and_return(true)
-          File.stub(:exist?).with("/etc/chef/zero.rb").and_return(false)
-          File.stub(:exist?).with("/etc/chef/secure/validation.pem").and_return(false)
-          File.stub(:exist?).with("/etc/chef/secure/client.pem").and_return(false)
+          allow(File).to receive(:exist?).with("/etc/chef/client.rb").and_return(true)
+          allow(File).to receive(:exist?).with("/etc/chef/zero.rb").and_return(false)
+          allow(File).to receive(:exist?).with("/etc/chef/secure/validation.pem").and_return(false)
+          allow(File).to receive(:exist?).with("/etc/chef/secure/client.pem").and_return(false)
         end
 
         it "errors out and prints a message" do
@@ -182,8 +182,8 @@ describe ChefInit::CLI do
 
     context "when valid configuration file does not exist" do
       before do
-        File.stub(:exist?).with("/etc/chef/client.rb").and_return(false)
-        File.stub(:exist?).with("/etc/chef/zero.rb").and_return(false)
+        allow(File).to receive(:exist?).with("/etc/chef/client.rb").and_return(false)
+        allow(File).to receive(:exist?).with("/etc/chef/zero.rb").and_return(false)
       end
 
       it "exits with error" do
@@ -231,12 +231,14 @@ describe ChefInit::CLI do
     let(:chefrun_pid) { 1001 }
 
     before do
-      cli.stub(:launch_supervisor).and_return(supervisor_pid)
-      cli.stub(:wait_for_supervisor)
-      cli.stub(:run_chef_client).and_return(chefrun_pid)
-      cli.stub(:waitpid_reap_other_children).with(chefrun_pid).and_return(0)
-      cli.stub(:waitpid_reap_other_children).with(supervisor_pid).and_return(0)
-      cli.stub(:delete_validation_key)
+      allow(cli).to receive(:launch_supervisor).and_return(supervisor_pid)
+      allow(cli).to receive(:wait_for_supervisor)
+      allow(cli).to receive(:run_chef_client).and_return(chefrun_pid)
+      allow(cli).to receive(:waitpid_reap_other_children).with(chefrun_pid).and_return(0)
+      allow(cli).to receive(:waitpid_reap_other_children).with(supervisor_pid).and_return(0)
+      allow(cli).to receive(:delete_validation_key)
+      allow(Process).to receive(:wait).with(supervisor_pid)
+      allow(Process).to receive(:wait).with(chefrun_pid)
     end
 
     it "launches process supervisor" do
@@ -288,15 +290,15 @@ describe ChefInit::CLI do
     let(:chefrun_pid) { 1001 }
 
     before do
-      cli.stub(:launch_supervisor).and_return(supervisor_pid)
-      cli.stub(:wait_for_supervisor)
-      cli.stub(:run_chef_client).and_return(chefrun_pid)
-      cli.stub(:waitpid_reap_other_children).with(chefrun_pid).and_return(0)
-      cli.stub(:delete_client_key)
-      cli.stub(:delete_node_name_file)
-      cli.stub(:shutdown_supervisor)
-      cli.stub(:empty_secure_directory)
-      cli.stub(:kill)
+      allow(cli).to receive(:launch_supervisor).and_return(supervisor_pid)
+      allow(cli).to receive(:wait_for_supervisor)
+      allow(cli).to receive(:run_chef_client).and_return(chefrun_pid)
+      allow(cli).to receive(:waitpid_reap_other_children).with(chefrun_pid).and_return(0)
+      allow(cli).to receive(:delete_client_key)
+      allow(cli).to receive(:delete_node_name_file)
+      allow(cli).to receive(:shutdown_supervisor)
+      allow(cli).to receive(:empty_secure_directory)
+      allow(cli).to receive(:kill)
     end
 
     it "launches the process supervisor" do
@@ -363,10 +365,7 @@ describe ChefInit::CLI do
       expect(cli).to receive(:fork) do |&block|
         expect(cli).to receive(:exec).with(
           {"PATH" => cli.path},
-          "/opt/chef/embedded/bin/runsvdir",
-          "-P",
-          "/opt/chef/service",
-          "'log: #{ '.' * 395}'"
+          "/opt/chef/embedded/bin/runsvdir -P /opt/chef/service 'log: #{ '.' * 395}'"
         )
         block.call
       end
@@ -375,7 +374,7 @@ describe ChefInit::CLI do
   end
 
   describe "#run_chef_client" do
-    before { cli.stub(:chef_client_command).and_return("chef-client") }
+    before { allow(cli).to receive(:chef_client_command).and_return("chef-client") }
 
     it "executes chef-client as a non-blocking sub-process" do
       expect(cli).to receive(:fork) do |&block|

--- a/spec/unit/chef-init/helpers_spec.rb
+++ b/spec/unit/chef-init/helpers_spec.rb
@@ -28,7 +28,7 @@ describe ChefInit::Helpers do
   describe ".system_command" do
     before do
      @klass = FakeClass.new
-     Mixlib::ShellOut.stub(:new).with("true").and_return(cmd)
+     allow(Mixlib::ShellOut).to receive(:new).with("true").and_return(cmd)
     end
 
     let(:cmd) { double("ShellOut Object", run_command: nil)}
@@ -52,7 +52,7 @@ describe ChefInit::Helpers do
   describe ".err" do
     before do
       @klass = FakeClass.new
-      @klass.stub(:stderr).and_return(stderr_io)  
+      allow(@klass).to receive(:stderr).and_return(stderr_io)
     end
 
     it "should print message to stderr" do
@@ -64,7 +64,7 @@ describe ChefInit::Helpers do
   describe ".msg" do
     before do
       @klass = FakeClass.new
-      @klass.stub(:stdout).and_return(stdout_io)  
+      allow(@klass).to receive(:stdout).and_return(stdout_io)
     end
 
     it "should print message to stdout" do
@@ -74,7 +74,7 @@ describe ChefInit::Helpers do
   end
 
   describe ".omnibus_root" do
-    before do 
+    before do
       @klass = FakeClass.new
     end
 

--- a/spec/unit/chef-init_spec.rb
+++ b/spec/unit/chef-init_spec.rb
@@ -57,8 +57,8 @@ describe ChefInit do
 
     context "when .node_name file exists" do
       before do
-        File.stub(:exist?).with("/etc/chef/.node_name").and_return(true)
-        File.stub(:read).with("/etc/chef/.node_name").and_return("docker-demo-build")
+        allow(File).to receive(:exist?).with("/etc/chef/.node_name").and_return(true)
+        allow(File).to receive(:read).with("/etc/chef/.node_name").and_return("docker-demo-build")
       end
 
       it "should return the contents of the file" do

--- a/spec/unit/chef/provider/container_service/runit_spec.rb
+++ b/spec/unit/chef/provider/container_service/runit_spec.rb
@@ -36,7 +36,7 @@ describe Chef::Provider::ContainerService::Runit do
 
     @provider = Chef::Provider::ContainerService::Runit.new(@new_resource, @run_context)
 
-    Chef::Resource::Service.stub(:new).and_return(@current_resource)
+    allow(Chef::Resource::Service).to receive(:new).and_return(@current_resource)
   end
 
   describe "#initialize" do
@@ -50,9 +50,9 @@ describe Chef::Provider::ContainerService::Runit do
   describe "#load_current_resource" do
     let(:command_success) { double("ShellOut Object", exitstatus: 0, stdout: 'run: ok') }
     before do
-      @provider.stub(:running?)
-      @provider.stub(:enabled?)
-      @provider.stub(:setup)
+      allow(@provider).to receive(:running?)
+      allow(@provider).to receive(:enabled?)
+      allow(@provider).to receive(:setup)
     end
 
     it "should setup the runit prerequisites" do
@@ -61,15 +61,15 @@ describe Chef::Provider::ContainerService::Runit do
     end
 
     it "should set the service_name" do
-      @provider.stub(:running?).and_return(true)
-      @provider.stub(:enabled?).and_return(true)
+      allow(@provider).to receive(:running?).and_return(true)
+      allow(@provider).to receive(:enabled?).and_return(true)
       @provider.load_current_resource
       expect(@current_resource.service_name).to eql("foo")
     end
 
     context "when supervisor is already running" do
       it "should set running to be true" do
-        @provider.stub(:running?).and_return(true)
+        allow(@provider).to receive(:running?).and_return(true)
         @provider.load_current_resource
         expect(@current_resource.running).to eql(true)
       end
@@ -77,7 +77,7 @@ describe Chef::Provider::ContainerService::Runit do
 
     context "when supervisor is not running" do
       it "should set running to be false" do
-        @provider.stub(:running?).and_return(false)
+        allow(@provider).to receive(:running?).and_return(false)
         @provider.load_current_resource
         expect(@current_resource.running).to eql(false)
       end
@@ -85,7 +85,7 @@ describe Chef::Provider::ContainerService::Runit do
 
     context "when supervisor is already enabled" do
       it "should set enabled to be true" do
-        @provider.stub(:enabled?).and_return(true)
+        allow(@provider).to receive(:enabled?).and_return(true)
         @provider.load_current_resource
         expect(@current_resource.enabled).to eql(true)
       end
@@ -93,7 +93,7 @@ describe Chef::Provider::ContainerService::Runit do
 
     context "when supervisor is not enabled" do
       it "should set enabled to be false" do
-        @provider.stub(:enabled?).and_return(false)
+        allow(@provider).to receive(:enabled?).and_return(false)
         @provider.load_current_resource
         expect(@current_resource.enabled).to eql(false)
       end
@@ -115,16 +115,16 @@ describe Chef::Provider::ContainerService::Runit do
     let(:service_dir_link) { double("service_dir_link", run_action: nil) }
 
     before do
-      @provider.stub(:staging_dir).and_return(staging_dir)
-      @provider.stub(:service_dir).and_return(service_dir)
-      @provider.stub(:down_file).and_return(down_file)
-      @provider.stub(:run_script).and_return(run_script)
-      @provider.stub(:log_dir).and_return(log_dir)
-      @provider.stub(:log_main_dir).and_return(log_main_dir)
-      @provider.stub(:log_run_script).and_return(log_run_script)
-      @provider.stub(:service_dir_link).and_return(service_dir_link)
-      @provider.stub(:running?).and_return(true)
-      @provider.stub(:enabled?).and_return(false)
+      allow(@provider).to receive(:staging_dir).and_return(staging_dir)
+      allow(@provider).to receive(:service_dir).and_return(service_dir)
+      allow(@provider).to receive(:down_file).and_return(down_file)
+      allow(@provider).to receive(:run_script).and_return(run_script)
+      allow(@provider).to receive(:log_dir).and_return(log_dir)
+      allow(@provider).to receive(:log_main_dir).and_return(log_main_dir)
+      allow(@provider).to receive(:log_run_script).and_return(log_run_script)
+      allow(@provider).to receive(:service_dir_link).and_return(service_dir_link)
+      allow(@provider).to receive(:running?).and_return(true)
+      allow(@provider).to receive(:enabled?).and_return(false)
     end
 
     it 'creates the service directory and run scripts' do
@@ -147,7 +147,7 @@ describe Chef::Provider::ContainerService::Runit do
     let(:down_file) { double("down_file resource", run_action: nil) }
 
     before do
-      @provider.stub(:down_file).and_return(down_file)
+      allow(@provider).to receive(:down_file).and_return(down_file)
     end
 
     it 'should delete down_file' do
@@ -160,8 +160,8 @@ describe Chef::Provider::ContainerService::Runit do
     let(:down_file) { double("down_file resource", run_action: nil) }
 
     before do
-      @provider.stub(:down_file).and_return(down_file)
-      @provider.stub(:shell_out)
+      allow(@provider).to receive(:down_file).and_return(down_file)
+      allow(@provider).to receive(:shell_out)
     end
 
     it 'should create down_file' do
@@ -177,8 +177,8 @@ describe Chef::Provider::ContainerService::Runit do
 
   describe "#start_service" do
     before do
-      @provider.stub(:shell_out!)
-      @provider.stub(:wait_for_service_enable)
+      allow(@provider).to receive(:shell_out!)
+      allow(@provider).to receive(:wait_for_service_enable)
     end
 
     it 'should send start command via sv' do
@@ -190,7 +190,7 @@ describe Chef::Provider::ContainerService::Runit do
 
   describe "#stop_service" do
     before do
-      @provider.stub(:shell_out!)
+      allow(@provider).to receive(:shell_out!)
     end
 
     it 'should send stop command via sv' do
@@ -201,7 +201,7 @@ describe Chef::Provider::ContainerService::Runit do
 
   describe "#restart_service" do
     before do
-      @provider.stub(:shell_out!)
+      allow(@provider).to receive(:shell_out!)
     end
 
     it 'should send restart command via sv' do
@@ -212,7 +212,7 @@ describe Chef::Provider::ContainerService::Runit do
 
   describe "#reload_service" do
     before do
-      @provider.stub(:shell_out!)
+      allow(@provider).to receive(:shell_out!)
     end
 
     it 'should send reload command via sv' do
@@ -228,7 +228,7 @@ describe Chef::Provider::ContainerService::Runit do
     let(:command) { double("shell_out", stdout: 'run: ok', exitstatus: 0)}
 
     before do
-      @provider.stub(:shell_out).and_return(command)
+      allow(@provider).to receive(:shell_out).and_return(command)
     end
 
     it "should get current status of process" do
@@ -242,7 +242,7 @@ describe Chef::Provider::ContainerService::Runit do
       let(:command) { double("shell_out", stdout: 'error: not ok', exitstatus: 1) }
 
       before do
-        @provider.stub(:shell_out).with(runit_signal("status")).and_return(command)
+        allow(@provider).to receive(:shell_out).with(runit_signal("status")).and_return(command)
       end
 
       it "should return false" do
@@ -255,7 +255,7 @@ describe Chef::Provider::ContainerService::Runit do
       let(:command) { double("shell_out", stdout: 'run: ok', exitstatus: 0) }
 
       before do
-        @provider.stub(:shell_out).with(runit_signal("status")).and_return(command)
+        allow(@provider).to receive(:shell_out).with(runit_signal("status")).and_return(command)
       end
 
       it "should return true" do
@@ -268,7 +268,7 @@ describe Chef::Provider::ContainerService::Runit do
   describe "#enabled?" do
     context "service is enabled" do
       before do
-        File.stub(:exists?).with("/opt/chef/service/foo/down").and_return(false)
+        allow(File).to receive(:exists?).with("/opt/chef/service/foo/down").and_return(false)
       end
 
       it "should return true" do
@@ -279,7 +279,7 @@ describe Chef::Provider::ContainerService::Runit do
 
     context "service is not enabled" do
       before do
-        File.stub(:exists?).with("/opt/chef/service/foo/down").and_return(true)
+        allow(File).to receive(:exists?).with("/opt/chef/service/foo/down").and_return(true)
       end
 
       it "should return true" do
@@ -335,7 +335,7 @@ describe Chef::Provider::ContainerService::Runit do
     let(:staging_dir) { double("staging_dir", recursive: nil, mode: nil) }
 
     before do
-      Chef::Resource::Directory.stub(:new).with("/opt/chef/sv/foo", anything).and_return(staging_dir)
+      allow(Chef::Resource::Directory).to receive(:new).with("/opt/chef/sv/foo", anything).and_return(staging_dir)
     end
 
     it 'should create the /opt/chef/sv/{service} directory' do
@@ -350,7 +350,7 @@ describe Chef::Provider::ContainerService::Runit do
     let(:down_file) { double("down_file", mode: nil, backup: nil) }
 
     before do
-      Chef::Resource::File.stub(:new).with("/opt/chef/sv/foo/down", anything).and_return(down_file)
+      allow(Chef::Resource::File).to receive(:new).with("/opt/chef/sv/foo/down", anything).and_return(down_file)
     end
 
     it 'should create the /opt/chef/sv/{service}/down file' do
@@ -364,8 +364,8 @@ describe Chef::Provider::ContainerService::Runit do
     let(:run_script) { double("run_script", content: nil, mode: nil) }
 
     before do
-      Chef::Resource::File.stub(:new).with("/opt/chef/sv/foo/run", anything).and_return(run_script)
-      @provider.stub(:run_script_content).and_return("go!")
+      allow(Chef::Resource::File).to receive(:new).with("/opt/chef/sv/foo/run", anything).and_return(run_script)
+      allow(@provider).to receive(:run_script_content).and_return("go!")
     end
 
     it 'should create the /opt/chef/sv/{service}/run file' do
@@ -380,7 +380,7 @@ describe Chef::Provider::ContainerService::Runit do
     let(:log_dir) { double("log_dir", recursive: nil, mode: nil) }
 
     before do
-      Chef::Resource::File.stub(:new).with("/var/log/foo", anything)
+      allow(Chef::Resource::File).to receive(:new).with("/var/log/foo", anything)
     end
 
     it 'should create the /var/log/{service} directory' do
@@ -395,7 +395,7 @@ describe Chef::Provider::ContainerService::Runit do
     let(:log_main_dir) { double("log_main_dir", recursive: nil, mode: nil) }
 
     before do
-      Chef::Resource::File.stub(:new).with("/opt/chef/sv/foo/log", anything)
+      allow(Chef::Resource::File).to receive(:new).with("/opt/chef/sv/foo/log", anything)
     end
 
     it 'should create the /var/log/{service} directory' do
@@ -410,8 +410,8 @@ describe Chef::Provider::ContainerService::Runit do
     let(:log_run_script) { double("log_run_script", content: nil, mode: nil) }
 
     before do
-      Chef::Resource::File.stub(:new).with("/opt/chef/sv/foo/log/run", anything).and_return(log_run_script)
-      @provider.stub(:log_run_script_content).and_return("go!")
+      allow(Chef::Resource::File).to receive(:new).with("/opt/chef/sv/foo/log/run", anything).and_return(log_run_script)
+      allow(@provider).to receive(:log_run_script_content).and_return("go!")
     end
 
     it 'should create the /opt/chef/sv/{service}/log/run file' do
@@ -426,7 +426,7 @@ describe Chef::Provider::ContainerService::Runit do
     let(:service_dir_link) { double("service_dir_link", to: nil) }
 
     before do
-      Chef::Resource::Link.stub(:new).with("/opt/chef/service/foo", anything).and_return(service_dir_link)
+      allow(Chef::Resource::Link).to receive(:new).with("/opt/chef/service/foo", anything).and_return(service_dir_link)
     end
 
     it 'creates a symlink between /opt/chef/sv/{service} and /opt/chef/service/{service}' do


### PR DESCRIPTION
- various cleanup tasks
- FSE-188:  Method for stripping secure credentials resulted in intermediate image with those credentials still present. Stripping out those intermediate layers is now the responsibility of `chef-init --bootstrap`. Reported by Andrew Hsu.
- Update rspec to use expect syntax
