### PR TITLE
FSE-207: runsvdir is still running during chef-container testing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 FROM chef/ubuntu-12.04:latest
-COPY pkg/chef-init-1.0.0.rc.0.gem chef-init.gem
+COPY pkg/chef-init-0.3.2.dev.gem chef-init.gem
 RUN /opt/chef/embedded/bin/gem install chef-init.gem --bindir '/opt/chef/bin' --no-ri --no-rdoc

--- a/chef-init.gemspec
+++ b/chef-init.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.add_dependency "mixlib-log", "~> 1.1"
   s.add_dependency "chef", "= 11.12.8"
   s.add_dependency "docker-api", "~> 1.11.1"
+  s.add_dependency 'sys-proctable', '~> 0.9.4'
 
   s.add_development_dependency "rake", "~> 10.1.0"
   s.add_development_dependency "rspec", "~> 2.14.0"

--- a/chef-init.gemspec
+++ b/chef-init.gemspec
@@ -13,7 +13,9 @@ Gem::Specification.new do |s|
   s.homepage      = "http://getchef.com"
   s.license       = "Apache 2.0"
 
-  s.files         = `git ls-files -z`.split("\x0")
+  s.files = %w(Rakefile README.md CONTRIBUTING.md) + Dir.glob("{lib,spec}/**/*", File::FNM_DOTMATCH).reject do |f|
+    File.directory?(f)
+  end
   s.executables   = s.files.grep(%r{^bin/}) { |f| File.basename(f) }
   s.test_files    = s.files.grep(%r{^(test|spec|features)/})
   s.require_paths = ["lib"]

--- a/lib/chef-init/cli.rb
+++ b/lib/chef-init/cli.rb
@@ -256,15 +256,10 @@ module ChefInit
     def wait_for_supervisor
       max_wait = 10
       wait = 0
-      running = false
-      begin
-        if @supervisor.running?
-          running = true
-        else
-          sleep 2
-          wait += 1
-        end
-      end until running || max_wait == wait
+      until @supervisor.running? || max_wait == wait
+        sleep 2
+        wait += 1
+      end
     end
 
     def supervisor_launch_command

--- a/lib/chef-init/process.rb
+++ b/lib/chef-init/process.rb
@@ -1,0 +1,123 @@
+#
+# Copyright:: Copyright (c) 2012-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'sys/proctable'
+require 'chef-init/helpers'
+
+module ChefInit
+  class Process
+    include Sys
+    include ChefInit::Helpers
+
+    @@terminated_child_processes = {}
+    @@monitor_child_processes = []
+
+    def self.find_by_name(name)
+      Proctable.ps do |proc|
+        if proc.cmdline =~ process_name
+          return proc.pid
+        end
+      end
+      raise NotFound
+    end
+
+    def self.running?(pid)
+      if id.is_a? Integer
+        Proctable.ps(id).nil?
+      elsif id.is_a? String
+        Proctable.ps(get_pid(id)).nil?
+      else
+        false
+      end
+    end
+
+    # Waits for the child process with the given PID, while at the same time
+    # reaping any other child processes that have exited (e.g. adopted child
+    # processes that have terminated).
+    # (code from https://github.com/phusion/baseimage-docker translated from python)
+    def self.wait(pid)
+      if @@terminated_child_processes.include?(pid)
+        # A previous call to waitpid_reap_other_children(),
+        # with an argument not equal to the current argument,
+        # already waited for this process. Return the status
+        # that was obtained back then.
+        return @@terminated_child_processes.delete(pid)
+      end
+      done = false
+      status = nil
+      until done
+        begin
+          this_pid, status = ::Process.wait2(-1, 0)
+          if this_pid == pid
+            done = true
+          elsif @@monitor_child_processes.include?(pid)
+            @@terminated_child_processes[this_pid] = status
+          end
+        rescue Errno::ECHILD, Errno::ESRCH
+          return
+        end
+      end
+      status
+    end
+
+    def self.kill(pid)
+      ::Process.kill('HUP', pid)
+      sleep 3
+      ::Process.kill('TERM', pid)
+      sleep 3
+      ::Process.kill('KILL', pid)
+      self.class.wait(pid)
+    end
+
+    attr_reader :pid
+    attr_reader :command
+    attr_reader :exitstatus
+
+    def initialize(command, path=Helpers.path)
+      @command = command
+      @pid = nil
+      @path = path
+    end
+
+    def launch
+      @pid = fork do
+        exec({"PATH" => @path}, @command)
+      end
+      @@monitor_child_processes << @pid
+      @pid
+    end
+
+    def kill
+      self.class.kill(@pid)
+    end
+
+    def wait
+      @exitstatus = self.class.wait(@pid)
+    end
+
+    def running?
+      self.class.running?(@pid)
+    end
+
+    class NotFound < RuntimeError
+      def initialize
+        super("The process you specified could not be found.")
+      end
+    end
+
+  end
+end

--- a/lib/chef-init/process.rb
+++ b/lib/chef-init/process.rb
@@ -28,7 +28,7 @@ module ChefInit
 
     def self.find_by_name(name)
       Proctable.ps do |proc|
-        if proc.cmdline =~ process_name
+        if proc.cmdline =~ name
           return proc.pid
         end
       end
@@ -41,7 +41,7 @@ module ChefInit
       elsif id.is_a? String
         Proctable.ps(get_pid(id)).nil?
       else
-        false
+        raise InvalidProcessID
       end
     end
 
@@ -119,5 +119,10 @@ module ChefInit
       end
     end
 
+    class InvalidProcessID < RuntimeError
+      def initialize
+        super("The process identified your provided is not valid.")
+      end
+    end
   end
 end

--- a/spec/unit/chef-init/cli_spec.rb
+++ b/spec/unit/chef-init/cli_spec.rb
@@ -37,10 +37,10 @@ describe ChefInit::CLI do
     allow(ChefInit::Log).to receive(:info)
 
     # by default, we are running in local-mode
-    allow(File).to receive(:exist?).with("/etc/chef/zero.rb").and_return(true)
-    allow(File).to receive(:exist?).with("/etc/chef/.node_name").and_return(false)
-    allow(File).to receive(:exist?).with("/etc/chef/secure/validation.pem").and_return(true)
-    allow(File).to receive(:exist?).with("/etc/chef/secure/client.pem").and_return(false)
+    allow(File).to receive(:exist?).with('/etc/chef/zero.rb').and_return(true)
+    allow(File).to receive(:exist?).with('/etc/chef/.node_name').and_return(false)
+    allow(File).to receive(:exist?).with('/etc/chef/secure/validation.pem').and_return(true)
+    allow(File).to receive(:exist?).with('/etc/chef/secure/client.pem').and_return(false)
   end
 
   subject(:cli) do
@@ -50,143 +50,143 @@ describe ChefInit::CLI do
     end
   end
 
-  describe "#run" do
+  describe '#run' do
     before do
       allow(cli).to receive(:launch_onboot)
       allow(cli).to receive(:launch_bootstrap)
     end
 
-    describe "when the application starts" do
+    describe 'when the application starts' do
       let(:argv) { %w[ --version ] }
 
-      it "parses the input" do
+      it 'parses the input' do
         expect(cli).to receive(:parse_options).and_call_original
         expect(cli).to receive(:exit).with(true)
         cli.run
       end
     end
 
-    describe "when onboot flag is passed" do
+    describe 'when onboot flag is passed' do
       let(:argv) { %w[ --onboot ] }
 
-      it "sets default options" do
+      it 'sets default options' do
         expect(cli).to receive(:set_default_options)
         cli.run
       end
 
-      it "launches onboot steps" do
+      it 'launches onboot steps' do
         expect(cli).to receive(:launch_onboot)
         cli.run
       end
     end
 
-    describe "when bootstrap flag is passed" do
+    describe 'when bootstrap flag is passed' do
       let(:argv) { %w[ --bootstrap ] }
 
-      it "sets default options" do
+      it 'sets default options' do
         expect(cli).to receive(:set_default_options)
         cli.run
       end
 
-      it "launches build steps" do
+      it 'launches build steps' do
         expect(cli).to receive(:launch_bootstrap)
         cli.run
       end
     end
 
-    describe "when verify flag is passed" do
+    describe 'when verify flag is passed' do
       let(:argv) { %w[ --verify ] }
-      let(:verify) { double("ChefInit::Verify", run: nil) }
+      let(:verify) { double('ChefInit::Verify', run: nil) }
 
-      it "runs the verification process" do
+      it 'runs the verification process' do
         allow(ChefInit::Verify).to receive(:new).and_return(verify)
         expect(verify).to receive(:run)
         cli.run
       end
     end
 
-    describe "when given no arguments or options" do
+    describe 'when given no arguments or options' do
       let(:argv) { [] }
-      it "alerts that you must pass in a flag or arguments" do
+      it 'alerts that you must pass in a flag or arguments' do
         expect(cli).to receive(:exit).with(false)
         cli.run
-        expect(stderr).to eql("You must pass in either the --onboot, " \
+        expect(stderr).to eql('You must pass in either the --onboot, ' \
           "--bootstrap, or --verify flag.\n")
       end
     end
 
-    describe "when version flas is passes" do
+    describe 'when version flag is passed' do
       let(:argv) { %w[ -v ] }
       let(:version_message) { "ChefInit Version: #{ChefInit::VERSION}\n" }
 
-      it "returns the version number and then exits" do
+      it 'returns the version number and then exits' do
         expect(cli).to receive(:exit).with(true)
         cli.run
         expect(stdout).to eql(version_message)
       end
     end
 
-    describe "when both bootstrap and onboot flags are given" do
+    describe 'when both bootstrap and onboot flags are given' do
       let(:argv) { %w[ --onboot --bootstrap ]}
-      it "gives an 'invalid option' message, the help output and exits" do
+      it 'gives an \'invalid option\' message, the help output and exits' do
         expect(cli).to receive(:exit).with(false)
         cli.run
-        expect(stderr).to eql("You must pass in either the --onboot OR the " \
+        expect(stderr).to eql('You must pass in either the --onboot OR the ' \
           "--bootstrap flag, but not both.\n")
       end
     end
 
   end
 
-  describe "#set_default_options" do
-    context "when zero.rb exists" do
+  describe '#set_default_options' do
+    context 'when zero.rb exists' do
       before do
-        allow(File).to receive(:exist?).with("/etc/chef/zero.rb").and_return(true)
-        allow(File).to receive(:exist?).with("/etc/chef/client.rb").and_return(false)
+        allow(File).to receive(:exist?).with('/etc/chef/zero.rb').and_return(true)
+        allow(File).to receive(:exist?).with('/etc/chef/client.rb').and_return(false)
       end
 
-      it "sets local-mode defaults" do
+      it 'sets local-mode defaults' do
         expect(cli).to receive(:set_local_mode_defaults)
         cli.set_default_options
       end
     end
 
-    context "when client.rb exists" do
+    context 'when client.rb exists' do
       before do
         allow(File).to receive(:exist?).with("/etc/chef/zero.rb").and_return(false)
         allow(File).to receive(:exist?).with("/etc/chef/client.rb").and_return(true)
       end
 
-      it "sets client-mode defaults" do
+      it 'sets client-mode defaults' do
         expect(cli).to receive(:set_server_mode_defaults)
         cli.set_default_options
       end
 
-      context "with missing validator and client keys" do
+      context 'with missing validator and client keys' do
         before do
-          allow(File).to receive(:exist?).with("/etc/chef/client.rb").and_return(true)
-          allow(File).to receive(:exist?).with("/etc/chef/zero.rb").and_return(false)
-          allow(File).to receive(:exist?).with("/etc/chef/secure/validation.pem").and_return(false)
-          allow(File).to receive(:exist?).with("/etc/chef/secure/client.pem").and_return(false)
+          allow(File).to receive(:exist?).with('/etc/chef/client.rb').and_return(true)
+          allow(File).to receive(:exist?).with('/etc/chef/zero.rb').and_return(false)
+          allow(File).to receive(:exist?).with('/etc/chef/secure/validation.pem').and_return(false)
+          allow(File).to receive(:exist?).with('/etc/chef/secure/client.pem').and_return(false)
         end
 
-        it "errors out and prints a message" do
+        it 'errors out and prints a message' do
           expect(cli).to receive(:exit).with(false)
           cli.set_default_options
-          expect(stderr).to eql("File /etc/chef/secure/validator.pem is missing." \
-            " Please make sure your secure credentials are accessible" \
+          expect(stderr).to eql('File /etc/chef/secure/validator.pem is missing.' \
+            ' Please make sure your secure credentials are accessible' \
             " to the running container.\n")
         end
       end
     end
 
-    context "when valid configuration file does not exist" do
+    context 'when valid configuration file does not exist' do
       before do
-        allow(File).to receive(:exist?).with("/etc/chef/client.rb").and_return(false)
-        allow(File).to receive(:exist?).with("/etc/chef/zero.rb").and_return(false)
+        allow(File).to receive(:exist?).with('/etc/chef/client.rb').and_return(false)
+        allow(File).to receive(:exist?).with('/etc/chef/zero.rb').and_return(false)
       end
 
-      it "exits with error" do
+      it 'exits with error' do
         expect(cli).to receive(:exit).with(false)
         cli.set_default_options
         expect(stderr).to eql("Cannot find a valid configuration file in /etc/chef\n")
@@ -194,7 +194,7 @@ describe ChefInit::CLI do
     end
   end
 
-  describe "#set_local_mode_defaults" do
+  describe '#set_local_mode_defaults' do
     before { cli.set_local_mode_defaults }
 
     it 'sets local mode to true' do
@@ -202,15 +202,15 @@ describe ChefInit::CLI do
     end
 
     it 'uses zero.rb for the config file' do
-      expect(cli.config[:config_file]).to eql("/etc/chef/zero.rb")
+      expect(cli.config[:config_file]).to eql('/etc/chef/zero.rb')
     end
 
     it 'uses first-boot.json for json attributes' do
-      expect(cli.config[:json_attribs]).to eql("/etc/chef/first-boot.json")
+      expect(cli.config[:json_attribs]).to eql('/etc/chef/first-boot.json')
     end
   end
 
-  describe "#set_server_mode_defaults" do
+  describe '#set_server_mode_defaults' do
     before { cli.set_server_mode_defaults }
 
     it 'sets local mode to false' do
@@ -218,140 +218,142 @@ describe ChefInit::CLI do
     end
 
     it 'uses client.rb for the config file' do
-      expect(cli.config[:config_file]).to eql("/etc/chef/client.rb")
+      expect(cli.config[:config_file]).to eql('/etc/chef/client.rb')
     end
 
     it 'uses first-boot.json for json attributes' do
-      expect(cli.config[:json_attribs]).to eql("/etc/chef/first-boot.json")
+      expect(cli.config[:json_attribs]).to eql('/etc/chef/first-boot.json')
     end
   end
 
-  describe "#launch_onboot" do
-    let(:supervisor_pid) { 1000 }
-    let(:chefrun_pid) { 1001 }
+  describe '#launch_onboot' do
+    let(:supervisor) { double('Supervisor', pid: 1000, launch: nil, wait: 0) }
+    let(:chefrun) { double('Chef Client Run', pid: 1001, launch: nil, wait: 0) }
+    let(:runit_cmd) { 'runsvdir -P' }
+    let(:chef_cmd) { 'chef-client' }
 
     before do
-      allow(cli).to receive(:launch_supervisor).and_return(supervisor_pid)
+      allow(cli).to receive(:supervisor_launch_command).and_return(runit_cmd)
+      allow(cli).to receive(:chef_client_command).and_return(chef_cmd)
+      allow(ChefInit::Process).to receive(:new).with(runit_cmd).and_return(supervisor)
       allow(cli).to receive(:wait_for_supervisor)
-      allow(cli).to receive(:run_chef_client).and_return(chefrun_pid)
-      allow(cli).to receive(:waitpid_reap_other_children).with(chefrun_pid).and_return(0)
-      allow(cli).to receive(:waitpid_reap_other_children).with(supervisor_pid).and_return(0)
+      allow(ChefInit::Process).to receive(:new).with(chef_cmd).and_return(chefrun)
       allow(cli).to receive(:delete_validation_key)
-      allow(Process).to receive(:wait).with(supervisor_pid)
-      allow(Process).to receive(:wait).with(chefrun_pid)
     end
 
-    it "launches process supervisor" do
-      expect(cli).to receive(:launch_supervisor)
+    it 'launches process supervisor' do
+      expect(supervisor).to receive(:launch)
       expect(cli).to receive(:exit).with(true)
       cli.launch_onboot
     end
 
-    it "waits for the supervisor to start" do
-      expect(cli).to receive(:wait_for_supervisor).and_return(supervisor_pid)
+    it 'waits for the supervisor to start' do
+      expect(cli).to receive(:wait_for_supervisor)
       expect(cli).to receive(:exit).with(true)
       cli.launch_onboot
     end
 
-    it "executes chef-client" do
-      expect(cli).to receive(:run_chef_client).and_return(chefrun_pid)
+    it 'executes chef-client' do
+      expect(chefrun).to receive(:launch)
       expect(cli).to receive(:exit).with(true)
       cli.launch_onboot
     end
 
     it 'waits for chef-client to finish' do
-      expect(cli).to receive(:waitpid_reap_other_children).with(chefrun_pid).and_return(0)
+      expect(chefrun).to receive(:wait).and_return(0)
       expect(cli).to receive(:exit).with(true)
       cli.launch_onboot
     end
 
-    it "deletes validation key when chef-client is finished" do
+    it 'deletes validation key when chef-client is finished' do
       expect(cli).to receive(:delete_validation_key)
       expect(cli).to receive(:exit).with(true)
       cli.launch_onboot
     end
 
-    it "catches SIGTERM and SIGKILL to shutdown supervisor" do
+    it 'catches SIGTERM and SIGKILL to shutdown supervisor' do
       expect(cli).to receive(:trap).with("TERM")
       expect(cli).to receive(:trap).with("KILL")
       expect(cli).to receive(:exit).with(true)
       cli.launch_onboot
     end
 
-    it "waits for supervisor to exit" do
-      expect(cli).to receive(:waitpid_reap_other_children).with(supervisor_pid).and_return(0)
+    it 'waits for supervisor to exit' do
+      expect(supervisor).to receive(:wait).and_return(0)
       expect(cli).to receive(:exit).with(true)
       cli.launch_onboot
     end
   end
 
-  describe "#launch_bootstrap" do
-    let(:supervisor_pid) { 1000 }
-    let(:chefrun_pid) { 1001 }
+  describe '#launch_bootstrap' do
+    let(:supervisor) { double('Supervisor', pid: 1000, launch: nil, wait: 0) }
+    let(:chefrun) { double('Chef Client Run', pid: 1001, launch: nil, wait: 0) }
+    let(:runit_cmd) { 'runsvdir -P' }
+    let(:chef_cmd) { 'chef-client' }
 
     before do
-      allow(cli).to receive(:launch_supervisor).and_return(supervisor_pid)
+      allow(cli).to receive(:supervisor_launch_command).and_return(runit_cmd)
+      allow(cli).to receive(:chef_client_command).and_return(chef_cmd)
+      allow(ChefInit::Process).to receive(:new).with(runit_cmd).and_return(supervisor)
       allow(cli).to receive(:wait_for_supervisor)
-      allow(cli).to receive(:run_chef_client).and_return(chefrun_pid)
-      allow(cli).to receive(:waitpid_reap_other_children).with(chefrun_pid).and_return(0)
+      allow(ChefInit::Process).to receive(:new).with(chef_cmd).and_return(chefrun)
       allow(cli).to receive(:delete_client_key)
       allow(cli).to receive(:delete_node_name_file)
       allow(cli).to receive(:shutdown_supervisor)
       allow(cli).to receive(:empty_secure_directory)
-      allow(cli).to receive(:kill)
     end
 
-    it "launches the process supervisor" do
-      expect(cli).to receive(:launch_supervisor).and_return(supervisor_pid)
+    it 'launches the process supervisor' do
+      expect(supervisor).to receive(:launch)
       expect(cli).to receive(:exit).with(true)
       cli.launch_bootstrap
     end
 
-    it "waits for the supervisor to start" do
+    it 'waits for the supervisor to start' do
       expect(cli).to receive(:wait_for_supervisor)
       expect(cli).to receive(:exit).with(true)
       cli.launch_bootstrap
     end
 
-    it "executes chef-client" do
-      expect(cli).to receive(:run_chef_client).and_return(chefrun_pid)
+    it 'executes chef-client' do
+      expect(chefrun).to receive(:launch)
       expect(cli).to receive(:exit).with(true)
       cli.launch_bootstrap
     end
 
     it 'waits for chef-client to finish' do
-      expect(cli).to receive(:waitpid_reap_other_children).with(chefrun_pid).and_return(0)
+      expect(chefrun).to receive(:wait).and_return(0)
       expect(cli).to receive(:exit).with(true)
       cli.launch_bootstrap
     end
 
-    it "deletes the client key after chef-client is finished" do
+    it 'deletes the client key after chef-client is finished' do
       expect(cli).to receive(:delete_client_key)
       expect(cli).to receive(:exit).with(true)
       cli.launch_bootstrap
     end
 
-    it "deletes the node name file if it exists" do
+    it 'deletes the node name file if it exists' do
       expect(cli).to receive(:delete_node_name_file)
       expect(cli).to receive(:exit).with(true)
       cli.launch_bootstrap
     end
 
-    it "shuts down the supervisor" do
+    it 'shuts down the supervisor' do
       expect(cli).to receive(:shutdown_supervisor)
       expect(cli).to receive(:exit).with(true)
       cli.launch_bootstrap
     end
 
-    it "deletes the secure directory" do
+    it 'deletes the secure directory' do
       expect(cli).to receive(:empty_secure_directory)
       expect(cli).to receive(:exit).with(true)
       cli.launch_bootstrap
     end
 
-    context "when --no-delete-secure is specified" do
+    context 'when --no-delete-secure is specified' do
       before { cli.config[:remove_secure] = false }
-      it "does not delete the secure directory" do
+      it 'does not delete the secure directory' do
         expect(cli).not_to receive(:empty_secure_directory)
         expect(cli).to receive(:exit).with(true)
         cli.launch_bootstrap
@@ -360,71 +362,42 @@ describe ChefInit::CLI do
 
   end
 
-  describe "#launch_supervisor" do
-    it "should launch supervisor as a non-blocking subprocess" do
-      expect(cli).to receive(:fork) do |&block|
-        expect(cli).to receive(:exec).with(
-          {"PATH" => cli.path},
-          "/opt/chef/embedded/bin/runsvdir -P /opt/chef/service 'log: #{ '.' * 395}'"
-        )
-        block.call
-      end
-      cli.launch_supervisor
-    end
-  end
-
-  describe "#run_chef_client" do
-    before { allow(cli).to receive(:chef_client_command).and_return("chef-client") }
-
-    it "executes chef-client as a non-blocking sub-process" do
-      expect(cli).to receive(:fork) do |&block|
-        expect(cli).to receive(:exec).with(
-          {"PATH" => cli.path},
-          "chef-client"
-        )
-        block.call
-      end
-      cli.run_chef_client
-    end
-  end
-
-  describe "#chef_client_command" do
-
-    describe "with local-mode defaults" do
+  describe '#chef_client_command' do
+    describe 'with local-mode defaults' do
       before do
         cli.config[:local_mode] = true
-        cli.config[:config_file] = "/etc/chef/zero.rb"
-        cli.config[:json_attribs] = "/etc/chef/first-boot.json"
+        cli.config[:config_file] = '/etc/chef/zero.rb'
+        cli.config[:json_attribs] = '/etc/chef/first-boot.json'
         cli.config[:log_level] = :info
       end
 
-      it { expect(cli.send(:chef_client_command)).to eql("chef-client -c " \
-        "/etc/chef/zero.rb -j /etc/chef/first-boot.json -l info -z") }
+      it { expect(cli.send(:chef_client_command)).to eql('chef-client -c ' \
+        '/etc/chef/zero.rb -j /etc/chef/first-boot.json -l info -z') }
     end
 
-    describe "with server-mode defaults" do
+    describe 'with server-mode defaults' do
       before do
         cli.config[:local_mode] = false
-        cli.config[:config_file] = "/etc/chef/client.rb"
-        cli.config[:json_attribs] = "/etc/chef/first-boot.json"
+        cli.config[:config_file] = '/etc/chef/client.rb'
+        cli.config[:json_attribs] = '/etc/chef/first-boot.json'
         cli.config[:log_level] = :info
       end
 
-      it { expect(cli.send(:chef_client_command)).to eql("chef-client -c " \
-        "/etc/chef/client.rb -j /etc/chef/first-boot.json -l info") }
+      it { expect(cli.send(:chef_client_command)).to eql('chef-client -c ' \
+        '/etc/chef/client.rb -j /etc/chef/first-boot.json -l info') }
     end
 
-    describe "with environment specified" do
+    describe 'with environment specified' do
       before do
         cli.config[:local_mode] = true
-        cli.config[:config_file] = "/etc/chef/zero.rb"
-        cli.config[:json_attribs] = "/etc/chef/first-boot.json"
+        cli.config[:config_file] = '/etc/chef/zero.rb'
+        cli.config[:json_attribs] = '/etc/chef/first-boot.json'
         cli.config[:log_level] = :info
-        cli.config[:environment] = "prod"
+        cli.config[:environment] = 'prod'
       end
 
-      it { expect(cli.send(:chef_client_command)).to eql("chef-client -c " \
-        "/etc/chef/zero.rb -j /etc/chef/first-boot.json -l info -z -E prod")}
+      it { expect(cli.send(:chef_client_command)).to eql('chef-client -c ' \
+        '/etc/chef/zero.rb -j /etc/chef/first-boot.json -l info -z -E prod')}
     end
   end
 end


### PR DESCRIPTION
Managing processes in chef-init was a PITA. To address this I created a new class called ChefInit::Process that used the sys-proctable gem to give me a more reliable way to find and interact with processes. All process management is now handled directly through that. The actual code that was being used didn't really change - it's just been shifted around. 

In addition, I cleaned up the rspec tests and fixed a few minor issues with the gemspec file and the Dockerfile. 
