### PR TITLE
Patch Chef::Resource::Service 'provider' setter and getter

### DIFF
--- a/lib/chef/resource/container_service.rb
+++ b/lib/chef/resource/container_service.rb
@@ -31,8 +31,18 @@ class Chef
           Chef::Log.info("Provider for service[#{@service_name}] has been " \
             "replaced with Chef::Provider::ContainerService::Runit")
           @provider = Chef::Provider::ContainerService::Runit
+
         end
       end
+
+      def provider(arg=nil)
+          Chef::Provider::ContainerService::Runit
+      end
+
+      def provider=(str)
+          @provider = Chef::Provider::ContainerService::Runit
+      end
+
 
       def container_service_command_specified?
         unless @run_context.nil? || @run_context.node.nil?


### PR DESCRIPTION
Rewrite provider setter and getter to avoid that service resource define in recipes can change provider.

For example this snippet in php5-fpm::install recipe:

``` ruby
#Enable and Restart PHP5-FPM
    service node["php_fpm"]["package"] do
     #Bug in 14.04 for service provider. Adding until resolved.
     if (platform?('ubuntu') && node['platform_version'].to_f >= 14.04)
        provider Chef::Provider::Service::Upstart
     end
     supports :start => true, :stop => true, :restart => true, :reload => true
     action [ :enable, :start ]
end
```
