### PR TITLE
fix supervisor/ok file not found when service is restarted

### DIFF
--- a/lib/chef/provider/container_service/runit.rb
+++ b/lib/chef/provider/container_service/runit.rb
@@ -108,6 +108,7 @@ class Chef
         end
 
         def restart_service
+          wait_for_service_enable
           shell_out!("#{sv_bin} restart #{service_dir_name}")
         end
 


### PR DESCRIPTION
The OpenStack StackForge cookbooks call 'restart' instead of 'start' after a service is enabled and configurations have been setup. This causes the file not found error as the pipe is still being created.
